### PR TITLE
添加域名

### DIFF
--- a/maintain_files/cdn.txt
+++ b/maintain_files/cdn.txt
@@ -3306,6 +3306,7 @@ g-svc.io
 gs.ww.np.dl.playstation.net
 gtags.net
 gtfund.com
+gtimg.cn
 gtimg.com
 gtja.com
 gtjazg.com
@@ -7064,6 +7065,7 @@ weand.com
 weartrends.com
 weathercn.com
 web20share.com
+webank.com
 webcname.net
 webdissector.com
 webfuns.net


### PR DESCRIPTION
gtimg.cn 是 QQ 某些业务的 CDN 域名，比如 QQ 空间的资源文件
webank.com 微众银行