### PR TITLE
增加一个三星应用商店地址

### DIFF
--- a/maintain_files/cdn.txt
+++ b/maintain_files/cdn.txt
@@ -20815,6 +20815,7 @@ salttiger.com
 samirchen.com
 samsunganycar.com
 samsung.com
+samsungapps.com
 samzeng.com
 sanban18.com
 sanbengzi.com


### PR DESCRIPTION
使用三星商店，由于没有这个存在在CDN加速，所以在大陆白名单会走SS流量，下载速度也因此减慢。添加三星应用商店的网址，可以有效加速下载应用的速度！