### PR TITLE
ddnspod改为用curl发送请求

### DIFF
--- a/ddnspod/ddnspod/ddnspod/ddnspod.sh
+++ b/ddnspod/ddnspod/ddnspod/ddnspod.sh
@@ -52,7 +52,7 @@ arIpAdress() {
 # 参数: 待查询域名
 arNslookup() {
     local inter="http://119.29.29.29/d?dn="
-    wget --quiet --output-document=- $inter$1
+    curl --silent $inter$1
 }
 
 # 读取接口数据
@@ -65,7 +65,7 @@ arApiPost() {
     else
         local param="login_token=${arToken}&format=json&${2}"
     fi
-    wget --quiet --no-check-certificate --output-document=- --user-agent=$agent --post-data $param $inter
+    curl -X POST --silent --insecure --user-agent $agent --data $param $inter
 }
 
 # 更新记录信息

--- a/ddnspod/ddnspod/ddnspod/ddnspod.sh
+++ b/ddnspod/ddnspod/ddnspod/ddnspod.sh
@@ -74,7 +74,7 @@ arDdnsUpdate() {
     local domainID recordID recordRS recordCD myIP errMsg
     # 获得域名ID
     domainID=$(arApiPost "Domain.Info" "domain=${1}")
-    domainID=$(echo $domainID | sed 's/.*{"id":"\([0-9]*\)".*/\1/')
+    domainID=$(echo $domainID | sed 's/.*"id":"\([0-9]*\)".*/\1/')
     # 获得记录ID
     recordID=$(arApiPost "Record.List" "domain_id=${domainID}&sub_domain=${2}")
     recordID=$(echo $recordID | sed 's/.*\[{"id":"\([0-9]*\)".*/\1/')


### PR DESCRIPTION
Fix #1027 

dnspod api地址 `https://dnsapi.cn` 的https协议已升级为TLSv1.2，而软件中心自带的 `wget v1.16` 并不支持TLSv1.2（1.16.1以上版本支持），改为用 `curl` 发送请求后一切正常
```console
admin@AC88U:/# wget --version
GNU Wget 1.16 built on linux-gnu.

admin@AC88U:/# wget --output-document - https://dnsapi.cn
--2019-03-09 12:07:01--  https://dnsapi.cn/
Resolving dnsapi.cn... 113.96.208.81
Connecting to dnsapi.cn|113.96.208.81|:443... connected.
OpenSSL: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version
Unable to establish SSL connection.

admin@AC88U:/# curl --user-agent ''  https://dnsapi.cn
<?xml version="1.0" encoding="UTF-8"?>
<dnspod>
<status>
<code>2</code>
<message>POST method accepted only</message>
<created_at>2019-03-09 12:07:34</created_at>
</status>
</dnspod>
```