### PR TITLE
添加 CloudFlare DDNS

### DIFF
--- a/softcenter/modules.json
+++ b/softcenter/modules.json
@@ -12,5 +12,6 @@
 {"module": "frps", "git_source": "https://github.com/koolshare/merlin_frps.git"},
 {"module": "softether", "git_source": "https://github.com/koolshare/merlin-SoftEtherVPN.git"},
 {"module": "gdddns", "git_source": "https://github.com/mritd/koolshare-gdddns.git"},
-{"module": "serverchan", "git_source": "https://github.com/koolshare/merlin_serverChan.git"}
+{"module": "serverchan", "git_source": "https://github.com/koolshare/merlin_serverChan.git"},
+{"module": "cfddns", "git_source": "https://github.com/geek5nan/koolshare-cfddns.git}
 ]


### PR DESCRIPTION
基于 [gdddns](https://github.com/mritd/koolshare-gdddns.git) 改写的 CloudFlare DDNS 插件，使用方式同 gddns 一致。